### PR TITLE
Update darwin code to initialize references regardless of the go compiler version

### DIFF
--- a/x509/nilref_nil_darwin.go
+++ b/x509/nilref_nil_darwin.go
@@ -1,0 +1,26 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build cgo,!arm,!arm64,!ios,!go1.10
+
+package x509
+
+/*
+#cgo CFLAGS: -mmacosx-version-min=10.6 -D__MAC_OS_X_VERSION_MAX_ALLOWED=1080
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
+
+#include <CoreFoundation/CoreFoundation.h>
+*/
+import "C"
+
+// For Go versions before 1.10, nil values for Apple's CoreFoundation
+// CF*Ref types were represented by nil.  See:
+//   https://github.com/golang/go/commit/b868616b63a8
+func setNilCFRef(v *C.CFDataRef) {
+	*v = nil
+}
+
+func isNilCFRef(v C.CFDataRef) bool {
+	return v == nil
+}

--- a/x509/nilref_zero_darwin.go
+++ b/x509/nilref_zero_darwin.go
@@ -1,0 +1,26 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build cgo,!arm,!arm64,!ios,go1.10
+
+package x509
+
+/*
+#cgo CFLAGS: -mmacosx-version-min=10.6 -D__MAC_OS_X_VERSION_MAX_ALLOWED=1080
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
+
+#include <CoreFoundation/CoreFoundation.h>
+*/
+import "C"
+
+// For Go versions >= 1.10, nil values for Apple's CoreFoundation
+// CF*Ref types are represented by zero.  See:
+//   https://github.com/golang/go/commit/b868616b63a8
+func setNilCFRef(v *C.CFDataRef) {
+	*v = 0
+}
+
+func isNilCFRef(v C.CFDataRef) bool {
+	return v == 0
+}

--- a/x509/root_darwin.go
+++ b/x509/root_darwin.go
@@ -70,7 +70,8 @@ func (c *Certificate) systemVerify(opts *VerifyOptions) (chains [][]*Certificate
 func initSystemRoots() {
 	roots := NewCertPool()
 
-	var data C.CFDataRef = 0
+	var data C.CFDataRef
+	setNilCFRef(&data)
 	err := C.FetchPEMRootsCTX509(&data)
 	if err == -1 {
 		return


### PR DESCRIPTION
Adopts https://github.com/google/certificate-transparency-go/pull/155 from upstream to build regardless of the Go compiler version.